### PR TITLE
Automated Cluster Orchestration

### DIFF
--- a/charts/dv-pod/README.md
+++ b/charts/dv-pod/README.md
@@ -21,6 +21,7 @@ A Helm chart for deploying a single distributed validator pod with Charon middle
 | centralMonitoring.enabled | bool | `false` | Specifies whether central monitoring should be enabled |
 | centralMonitoring.promEndpoint | string | `"https://vm.monitoring.gcp.obol.tech/write"` | https endpoint to obol central prometheus  |
 | centralMonitoring.token | string | `""` | The authentication token to the central prometheus |
+| chainId | int | `560048` | Chain ID for the network (1: Mainnet, 100: Gnosis, 560048: Hoodi) |
 | charon.beaconNodeEndpoints | list | `["http://beacon-node:5052"]` | Beacon node endpoints (used when sub-charts are disabled) These will be used by both Charon and the validator client |
 | charon.beaconNodeHeaders | string | `""` | Beacon node authentication headers WARNING: These headers will be sent to ALL beacon nodes, which could leak credentials Format: "Authorization=Basic <base64_encoded_credentials>" To generate: echo -n "username:password" | base64 Example: "Authorization=Basic am9objpkb2U=" |
 | charon.beaconNodeHeadersSecretKey | string | `"headers"` | Key within the beacon node headers secret |


### PR DESCRIPTION
This PR introduces the new `dv-pod` Helm chart, designed to deploy a single distributed validator pod with Charon middleware and an integrated validator client. This chart simplifies the deployment of distributed validators by providing a single-pod architecture suitable for solo stakers and small operators.

### Key Features

#### 🚀 DKG Sidecar Integration
- Automated DKG (Distributed Key Generation) process via init container
- Integrates the [charon-dkg-sidecar](https://github.com/ObolNetwork/charon-dkg-sidecar) image
- Supports three operating modes:
  - Pre-existing cluster-lock.json (skip DKG)
  - Pre-existing cluster-definition.json (run DKG locally)
  - Automatic DKG via Obol API polling

#### 🔑 ENR Key Management
- Automatic ENR private key generation via Kubernetes Job
- Support for providing existing ENR keys
- Secure storage in Kubernetes Secrets

#### 📦 Large Cluster-Lock Support (Lock Hash)
- Handles cluster-lock.json files larger than 1MB (ConfigMap limit)
- **Two approaches available:**
  - **Direct lock hash** (Recommended): `--set charon.lockHash=$LOCK_HASH`
  - **ConfigMap method**: Store lock hash in ConfigMap
- The DKG sidecar fetches the full cluster lock from Obol API using the lock hash
- Documented workaround with clear examples for both methods

#### 💼 Validator Keystore Management
- Comprehensive keystore import system for all major validator clients
- Supports both pre-existing keystores (via Secrets) and DKG-generated keystores
- Client-specific directory structures:
  - Lighthouse: Standard keystore/password file structure
  - Lodestar: Pubkey-based directory structure
  - Teku: Separate keys and passwords directories
  - Prysm & Nimbus: Similar to Lighthouse
- Automatic import init container handles all formatting

#### 🎯 Integrated Validator Client
- Built-in support for multiple validator clients:
  - Lighthouse (default)
  - Teku
  - Lodestar
  - Prysm
  - Nimbus
- Automatic configuration to connect to Charon's validator API
- Configurable graffiti and extra arguments
- Option to use external validator clients

#### 💾 Persistent Storage
- Configurable persistence for DKG artifacts
- **Always-on persistence for validator data** to prevent slashing
- Separate PVCs for charon-data and validator-data
- EmptyDir fallback for charon-data when persistence is disabled

#### 🧪 Comprehensive Test Suite
- ENR generation tests
- DKG sidecar integration tests with mock API server
- Mock API service naming corrected (`test-dkg-mock-api-service`)
- RBAC validation tests
- Test values updated to match current chart structure

### Chart Structure

```
charts/dv-pod/
├── Chart.yaml                 # Chart metadata
├── values.yaml               # Default configuration
├── test-values.yaml          # Test-specific values
├── templates/
│   ├── statefulset.yaml     # Main pod with Charon + validator client
│   ├── hooks-enr-job.yaml   # ENR generation job
│   └── tests/               # Helm test suite
└── README.md                # Comprehensive documentation
```

### Usage Examples

```bash
# Basic deployment with automatic DKG
helm install my-dv-pod obol/dv-pod \
  --set charon.operatorAddress=0xYOUR_ADDRESS \
  --set charon.beaconNodeEndpoints[0]=http://beacon:5052

# With pre-existing cluster-lock
kubectl create configmap cluster-lock --from-file=cluster-lock.json
helm install my-dv-pod obol/dv-pod \
  --set configMaps.clusterlock=cluster-lock

# With lock hash for large cluster-lock files (>1MB)
LOCK_HASH=$(jq -r '.lock_hash' cluster-lock.json)
helm install my-dv-pod obol/dv-pod \
  --set charon.lockHash=$LOCK_HASH \
  --set charon.operatorAddress=0xYOUR_ADDRESS

# With pre-existing validator keystores
kubectl create secret generic validator-keys \
  --from-file=keystore-0.json \
  --from-file=keystore-0.txt
helm install my-dv-pod obol/dv-pod \
  --set validatorClient.keystores.secretName=validator-keys \
  --set configMaps.clusterlock=cluster-lock
```

### Breaking Changes

- `configMaps.configHash` has been renamed to `configMaps.lockHash` for clarity and consistency

### Migration Path

This chart is designed as a modern single-pod solution for distributed validators:
- Simplified configuration compared to multi-node cluster setups
- Better resource efficiency for solo stakers
- Easier maintenance and upgrades
- Full compatibility with the Obol network
- Clear upgrade path from testing to production

### Documentation

Comprehensive documentation includes:
- Prerequisites and deployment options
- Handling of large cluster-lock files with lock hash
- Validator client configuration for all supported clients
- Advanced usage scenarios (external validators)
- Troubleshooting guides
- Test configuration examples

### Technical Improvements

- Validator data always uses persistent storage (even when persistence.enabled=false)
- Mock API service endpoint corrected in test values
- Removed duplicate entries in values.yaml
- Added network configuration for Teku validator
- Improved error handling for missing operator address
- Clear separation between charon-data and validator-data persistence

### Related Changes

- Minor version updates to charon and charon-cluster chart READMEs (v1.5.1)
- All DKG sidecar implementation moved to external repository
- Test infrastructure includes mock API server for integration testing

This chart represents a significant step forward in making distributed validators more accessible and easier to deploy for the Ethereum staking community.