### PR TITLE
feat: change from configHash to lockHash for large cluster-lock files

### DIFF
--- a/charts/dv-pod/README.md.gotmpl
+++ b/charts/dv-pod/README.md.gotmpl
@@ -105,28 +105,40 @@ If your cluster-lock.json file is larger than 1MB, you may encounter errors when
 error validating data: ValidationError(ConfigMap.data.cluster-lock.json): invalid type for io.k8s.api.core.v1.ConfigMap.data: got "array", expected "string"
 ```
 
-In this case, you can use the config hash approach:
+In this case, you have two options:
 
-1. First, extract the config_hash from your cluster-lock.json:
+**Option A: Direct lock hash (Recommended)**
+
+1. Extract the lock_hash from your cluster-lock.json:
    ```console
-   CONFIG_HASH=$(jq -r '.cluster_definition.config_hash' cluster-lock.json)
-   echo $CONFIG_HASH
+   LOCK_HASH=$(jq -r '.lock_hash' cluster-lock.json)
+   echo $LOCK_HASH
    ```
 
-2. Create a ConfigMap with just the config hash:
-   ```console
-   kubectl create configmap cluster-config-hash \
-     --from-literal=config-hash=$CONFIG_HASH
-   ```
-
-3. Install the chart with the configHash option:
+2. Install the chart with the lockHash value:
    ```console
    helm install my-dv-pod obol/dv-pod \
-     --set configMaps.configHash=cluster-config-hash \
+     --set charon.lockHash=$LOCK_HASH \
      --set charon.operatorAddress=<YOUR_OPERATOR_ADDRESS>
    ```
 
-The DKG sidecar will use this config hash to fetch the full cluster definition from the Obol API.
+**Option B: ConfigMap approach**
+
+1. Extract the lock_hash and create a ConfigMap:
+   ```console
+   LOCK_HASH=$(jq -r '.lock_hash' cluster-lock.json)
+   kubectl create configmap cluster-lock-hash \
+     --from-literal=lock-hash=$LOCK_HASH
+   ```
+
+2. Install the chart referencing the ConfigMap:
+   ```console
+   helm install my-dv-pod obol/dv-pod \
+     --set configMaps.lockHash=cluster-lock-hash \
+     --set charon.operatorAddress=<YOUR_OPERATOR_ADDRESS>
+   ```
+
+The DKG sidecar will use the lock hash to fetch the full cluster lock from the Obol API.
 
 ### Option 2: Run DKG through the chart (automatic)
 

--- a/charts/dv-pod/templates/statefulset.yaml
+++ b/charts/dv-pod/templates/statefulset.yaml
@@ -94,6 +94,10 @@ spec:
               value: "/charon-data"
             - name: CHARON_PRIVATE_KEY_FILE
               value: "/charon-data/charon-enr-private-key"
+            {{- if .Values.charon.lockHash }}
+            - name: LOCK_HASH
+              value: "{{ .Values.charon.lockHash }}"
+            {{- end }}
           volumeMounts:
             - name: enr-data
               mountPath: /enr-from-job
@@ -107,11 +111,11 @@ spec:
               subPath: cluster-lock.json
               readOnly: true
             {{- end }}
-            {{- if .Values.configMaps.configHash }}
-            # Mount config-hash for large cluster-lock files
-            - name: config-hash
-              mountPath: /charon-data/config-hash
-              subPath: config-hash
+            {{- if .Values.configMaps.lockHash }}
+            # Mount lock-hash for large cluster-lock files
+            - name: lock-hash
+              mountPath: /charon-data/lockhash
+              subPath: lock-hash
               readOnly: true
             {{- end }}
             - name: charon-enr-key
@@ -503,14 +507,14 @@ spec:
         - name: cluster-lock
           emptyDir: {}
         {{- end }}
-        {{- if .Values.configMaps.configHash }}
-        # Volume for config-hash ConfigMap (large cluster-lock files)
-        - name: config-hash
+        {{- if .Values.configMaps.lockHash }}
+        # Volume for lock-hash ConfigMap (large cluster-lock files)
+        - name: lock-hash
           configMap:
-            name: {{ .Values.configMaps.configHash }}
+            name: {{ .Values.configMaps.lockHash }}
             items:
-            - key: config-hash
-              path: config-hash
+            - key: lock-hash
+              path: lock-hash
         {{- end }}
         # Volume for the shared ENR private key
         - name: charon-enr-key

--- a/charts/dv-pod/values.yaml
+++ b/charts/dv-pod/values.yaml
@@ -376,6 +376,12 @@ charon:
 
   # -- Path within the Charon container where the ENR private key file will be mounted.
   privateKeyFile: "/data/charon-enr-private-key"
+  
+  # -- Lock hash for large cluster-lock files
+  # If your cluster-lock.json is larger than 1MB, extract the lock_hash value
+  # and provide it here. The DKG sidecar will fetch the full cluster lock from the Obol API.
+  # Example: --set charon.lockHash="0xabc123..."
+  lockHash: ""
 
 # -- Kubernetes secrets names that might be used as suffixes or for other purposes.
 # For the ENR, the secret name is either defined in 'charon.enr.existingSecret.name' 
@@ -396,12 +402,13 @@ configMaps:
   # more suitable for cluster-lock files which can be several megabytes.
   clusterlock: ""
   
-  # -- Name of the ConfigMap containing the config-hash
-  # Use this when your cluster-lock.json is too large (>1MB) for a ConfigMap.
-  # The ConfigMap should contain a key 'config-hash' with the value from 
-  # cluster_definition.config_hash in your cluster-lock.json
-  # Example: kubectl create configmap cluster-config-hash --from-literal=config-hash=$CONFIG_HASH
-  configHash: ""
+  # -- Name of the ConfigMap containing the lock-hash
+  # Alternative method for large cluster-lock files (>1MB).
+  # The ConfigMap should contain a key 'lock-hash' with the lock_hash value
+  # from your cluster-lock.json
+  # Example: kubectl create configmap cluster-lock-hash --from-literal=lock-hash=$LOCK_HASH
+  # Note: Using charon.lockHash directly is recommended over this method
+  lockHash: ""
 
 # -- Persistence configuration for DKG artifacts and charon data
 persistence:


### PR DESCRIPTION
## Summary
- Changed from `configHash` to `lockHash` for handling large cluster-lock files (>1MB)
- Added `charon.lockHash` parameter for direct configuration via `--set`
- Renamed `configMaps.configHash` to `configMaps.lockHash` for consistency
- Updated mount path to `/charon-data/lockhash` to match DKG sidecar expectations

## Changes
- **values.yaml**: Added `charon.lockHash` parameter and renamed `configMaps.configHash` to `configMaps.lockHash`
- **statefulset.yaml**: Added `LOCK_HASH` environment variable support and updated volume mounts
- **README.md**: Updated documentation to show both approaches (direct lockHash and ConfigMap)

## Usage
Users can now provide lock hash in two ways:

**Option A: Direct value (Recommended)**
```bash
helm install my-dv-pod obol/dv-pod \
  --set charon.lockHash=$LOCK_HASH \
  --set charon.operatorAddress=<OPERATOR_ADDRESS>
```

**Option B: Via ConfigMap**
```bash
kubectl create configmap cluster-lock-hash \
  --from-literal=lock-hash=$LOCK_HASH

helm install my-dv-pod obol/dv-pod \
  --set configMaps.lockHash=cluster-lock-hash \
  --set charon.operatorAddress=<OPERATOR_ADDRESS>
```