### PR TITLE
Updates default image for obol-app to something that exits

### DIFF
--- a/charts/obol-app/README.md
+++ b/charts/obol-app/README.md
@@ -21,8 +21,8 @@ helm repo update
 
 **Install the chart:**
 ```sh
-# Install with default nginx image for testing
-helm install my-web-app obol/obol-app
+# Install with default busybox image (displays Obol ASCII art for 30 seconds)
+helm install my-demo-app obol/obol-app
 
 # Or install with a custom image
 helm install my-app obol/obol-app --set image.repository=alpine
@@ -213,12 +213,14 @@ helm list | grep obol-app | awk '{print $1}' | xargs -n1 helm uninstall
 | image.args | list | `[]` |  |
 | image.auth.enabled | bool | `false` |  |
 | image.auth.secretName | string | `""` |  |
-| image.command | list | `[]` |  |
+| image.command[0] | string | `"sh"` |  |
+| image.command[1] | string | `"-c"` |  |
+| image.command[2] | string | `"echo '.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo'; echo '  ___  ____   ___  _            _    ____  ____  '; echo ' / _ \\| __ ) / _ \\| |          / \\  |  _ \\|  _ \\  Run a Docker container'; echo '| | | |  _ \\| | | | |   _____ / _ \\ | |_) | |_) |   in the Obol Stack'; echo '| |_| | |_) | |_| | |__|_____/ ___ \\|  __/|  __/       using Helm'; echo ' \\___/|____/ \\___/|_____|   /_/   \\_\\_|   |_|    '; echo ''; echo '.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo'; echo ''; echo '  This is an example Obol App!'; echo 'Choose a more exciting docker image to run next.'; echo ''; echo 'Exiting after 30 seconds...'; sleep 30; exit 0"` |  |
 | image.entrypoint | list | `[]` |  |
 | image.environment | list | `[]` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.registry | string | `""` |  |
-| image.repository | string | `"nginx"` |  |
+| image.repository | string | `"busybox"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |

--- a/charts/obol-app/README.md.gotmpl
+++ b/charts/obol-app/README.md.gotmpl
@@ -22,8 +22,8 @@ helm repo update
 
 **Install the chart:**
 ```sh
-# Install with default nginx image for testing
-helm install my-web-app obol/obol-app
+# Install with default busybox image (displays Obol ASCII art for 30 seconds)
+helm install my-demo-app obol/obol-app
 
 # Or install with a custom image
 helm install my-app obol/obol-app --set image.repository=alpine

--- a/charts/obol-app/values.yaml
+++ b/charts/obol-app/values.yaml
@@ -9,7 +9,7 @@ replicaCount: 1
 image:
   # Custom registry support (optional)
   registry: ""
-  repository: nginx
+  repository: busybox
   # This sets the pull policy for images.
   pullPolicy: IfNotPresent
   # Specifies the Docker Image tag. (default "latest")
@@ -29,9 +29,9 @@ image:
   # Example: ["--verbose", "--timeout", "30"]
   args: []
 
-  # Override the Docker image's CMD
+  # Override the Docker image's CMD - configured to display ASCII art and exit after 30 seconds
   # Example: ["--config", "/app/config.yaml"]
-  command: []
+  command: ["sh", "-c", "echo '.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo'; echo '  ___  ____   ___  _            _    ____  ____  '; echo ' / _ \\| __ ) / _ \\| |          / \\  |  _ \\|  _ \\  Run a Docker container'; echo '| | | |  _ \\| | | | |   _____ / _ \\ | |_) | |_) |   in the Obol Stack'; echo '| |_| | |_) | |_| | |__|_____/ ___ \\|  __/|  __/       using Helm'; echo ' \\___/|____/ \\___/|_____|   /_/   \\_\\_|   |_|    '; echo ''; echo '.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo.oOo'; echo ''; echo '  This is an example Obol App!'; echo 'Choose a more exciting docker image to run next.'; echo ''; echo 'Exiting after 30 seconds...'; sleep 30; exit 0"]
 
   # Custom environment variables for the container
   environment: []


### PR DESCRIPTION
The main release job is failing because obol-app no longer has a default readiness check (for non http containers) but also doesn't exit (because its nginx). Swaps to a busybox image default that exits after a console.log and timeout. 