### PR TITLE
fix(dv-pod): Write cluster-definition.json to /tmp

### DIFF
--- a/charts/dv-pod/Chart.yaml
+++ b/charts/dv-pod/Chart.yaml
@@ -31,7 +31,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.2
+version: 0.4.3
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/dv-pod/README.md
+++ b/charts/dv-pod/README.md
@@ -2,7 +2,7 @@
 DV-Pod
 ===========
 
-![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.1](https://img.shields.io/badge/AppVersion-1.7.1-informational?style=flat-square)
+![Version: 0.4.3](https://img.shields.io/badge/Version-0.4.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.1](https://img.shields.io/badge/AppVersion-1.7.1-informational?style=flat-square)
 
 A Helm chart for deploying a single distributed validator pod consisting of a Charon middleware client and validator client.
 

--- a/charts/dv-pod/templates/statefulset.yaml
+++ b/charts/dv-pod/templates/statefulset.yaml
@@ -90,7 +90,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: OUTPUT_DEFINITION_FILE
-              value: "/charon-data/cluster-definition.json"
+              value: "/tmp/cluster-definition.json"
             - name: API_ENDPOINT
               value: "{{ .Values.charon.dkgSidecar.apiEndpoint }}"
             - name: INITIAL_RETRY_INTERVAL_SECONDS


### PR DESCRIPTION
This PR addresses a `permission denied` error encountered by the DKG sidecar when attempting to write `cluster-definition.json` to the `/charon-data` volume, particularly in environments utilizing storage provisioners like `local-path`.

### Changes

 -   **Redirected `cluster-definition.json` output:** The `OUTPUT_DEFINITION_FILE` environment variable for the DKG sidecar has been changed from `/charon-data/cluster-definition.json` to `/tmp/cluster-definition.json`
      This ensures that the transient `cluster-definition.json` file is written to a universally writable temporary directory, bypassing permission issues on the persistent volume.
-   **Chart Version Bump:** The `dv-pod` chart version has been updated to `0.4.3`.
-   **Documentation Update:** The `README.md` file has been regenerated to reflect the chart version bump.

This change resolves the immediate `EACCES` error for `cluster-definition.json` without modifying the core volume permissions, as the definition file is an ephemeral input to the `charon dkg` process and does not require persistence.
