### PR TITLE
fix: enforce semantic commits in Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "semanticCommits": "enabled",
   "enabledManagers": [
     "github-actions",
     "custom.regex"

--- a/charts/charon-relay/Chart.yaml
+++ b/charts/charon-relay/Chart.yaml
@@ -29,7 +29,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.1
+version: 0.5.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/charon-relay/README.md
+++ b/charts/charon-relay/README.md
@@ -2,7 +2,7 @@
 Charon Relay
 ===========
 
-![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.9.3](https://img.shields.io/badge/AppVersion-1.9.3-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.9.3](https://img.shields.io/badge/AppVersion-1.9.3-informational?style=flat-square)
 
 Charon is an open-source Ethereum Distributed validator middleware written in golang. This chart deploys a libp2p relay server.
 
@@ -30,6 +30,9 @@ Charon is an open-source Ethereum Distributed validator middleware written in go
 | config.httpAddress | string | `"0.0.0.0:3640"` | Listening address (ip and port) for the relay http server serving runtime ENR. (default "127.0.0.1:3640") |
 | config.logFormat | string | `"json"` | Log format; console, logfmt or json (default "console") |
 | config.logLevel | string | `"debug"` | Log level; debug, info, warn or error (default "info") |
+| config.loki | object | `{"existingSecret":{"key":"url","name":""}}` | Use an existing Kubernetes Secret for the Loki URL instead of plain lokiAddresses value |
+| config.loki.existingSecret.key | string | `"url"` | Key in the secret containing the Loki URL |
+| config.loki.existingSecret.name | string | `""` | Name of the existing secret containing the Loki URL |
 | config.lokiAddresses | string | `""` | Enables sending of logfmt structured logs to these Loki log aggregation server addresses. This is in addition to normal stderr logs. |
 | config.lokiService | string | `""` | Service label sent with logs to Loki. |
 | config.monitoringAddress | string | `"0.0.0.0:3620"` | Listening address (ip and port) for the monitoring API (prometheus, pprof). (default "127.0.0.1:3620") |

--- a/charts/charon-relay/templates/statefulset.yaml
+++ b/charts/charon-relay/templates/statefulset.yaml
@@ -104,7 +104,7 @@ spec:
               {{- if $.Values.config.logLevel }}
               --log-level={{ $.Values.config.logLevel }}
               {{- end }}
-              {{- if $.Values.config.lokiAddresses }}
+              {{- if and $.Values.config.lokiAddresses (not $.Values.config.loki.existingSecret.name) }}
               --loki-addresses={{ $.Values.config.lokiAddresses }}
               {{- end }}
               {{- if $.Values.config.lokiService }}
@@ -146,6 +146,13 @@ spec:
                 fieldPath: metadata.name
           - name: KUBERNETES_CLUSTER_DOMAIN
             value: {{ $.Values.kubernetesClusterDomain }}
+          {{- if $.Values.config.loki.existingSecret.name }}
+          - name: CHARON_LOKI_ADDRESSES
+            valueFrom:
+              secretKeyRef:
+                name: {{ $.Values.config.loki.existingSecret.name }}
+                key: {{ $.Values.config.loki.existingSecret.key | default "url" }}
+          {{- end }}
           image: {{ $.Values.image.repository }}:{{ $.Values.image.tag }}
           name: {{ $.Chart.Name }}
           {{- with $.Values.containerSecurityContext }}

--- a/charts/charon-relay/values.yaml
+++ b/charts/charon-relay/values.yaml
@@ -175,9 +175,17 @@ config:
 
   # --  Enables sending of logfmt structured logs to these Loki log aggregation server addresses. This is in addition to normal stderr logs.
   lokiAddresses: ""
-  
+
   # -- Service label sent with logs to Loki.
   lokiService: ""
+
+  # -- Use an existing Kubernetes Secret for the Loki URL instead of plain lokiAddresses value
+  loki:
+    existingSecret:
+      # -- Name of the existing secret containing the Loki URL
+      name: ""
+      # -- Key in the secret containing the Loki URL
+      key: "url"
 
   # -- Listening address (ip and port) for the monitoring API (prometheus, pprof). (default "127.0.0.1:3620")
   monitoringAddress: "0.0.0.0:3620"


### PR DESCRIPTION
Renovate v43.104.0 changed its semantic commit auto-detector. Fix: explicitly set `"semanticCommits": "enabled"` instead of relying on auto-detection.