### PR TITLE
feat(dv-pod): add fetchFeeRecipientUpdates charon flag

### DIFF
--- a/charts/dv-pod/README.md
+++ b/charts/dv-pod/README.md
@@ -350,6 +350,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | charon.featureSet | string | `"stable"` | Minimum feature set to enable by default: alpha, beta, or stable. Warning: modify at own risk. (default "stable") |
 | charon.featureSetDisable | string | `""` | Comma-separated list of features to disable, overriding the default minimum feature set. |
 | charon.featureSetEnable | string | `""` | Comma-separated list of features to enable, overriding the default minimum feature set. |
+| charon.fetchFeeRecipientUpdates | bool | `true` | Enables polling the Obol API for signed fee recipient update messages that override the currently configured fee recipient. |
 | charon.lockFile | string | `"/charon-data/cluster-lock.json"` | The path on the pod to the cluster lock file that definesthe distributed validator cluster. (default "/charon-data/cluster-lock.json") |
 | charon.lockHash | string | `""` | Cluster lock hash for large cluster-lock files (>1MB) When provided, the DKG sidecar will fetch the full cluster-lock from Obol API using this hash Extract the hash from a cluster-lock.json using: `jq -r '.lock_hash' cluster-lock.json` Alternative to providing the full cluster-lock.json file via the configMaps.clusterLock value |
 | charon.logFormat | string | `"json"` | Log format; console, logfmt or json (default "json") |

--- a/charts/dv-pod/templates/statefulset.yaml
+++ b/charts/dv-pod/templates/statefulset.yaml
@@ -538,6 +538,7 @@ spec:
               {{- if .Values.charon.featureSetEnable }}
               --feature-set-enable={{ .Values.charon.featureSetEnable }}
               {{- end }}
+              --fetch-feerecipient-updates={{ .Values.charon.fetchFeeRecipientUpdates }}
               {{- if .Values.charon.logFormat }}
               --log-format={{ .Values.charon.logFormat }}
               {{- end }}

--- a/charts/dv-pod/values.schema.json
+++ b/charts/dv-pod/values.schema.json
@@ -248,6 +248,10 @@
                     "description": "Comma-separated list of features to enable, overriding the default minimum feature set.",
                     "type": "string"
                 },
+                "fetchFeeRecipientUpdates": {
+                    "description": "Enables polling the Obol API for signed fee recipient update messages that override the currently configured fee recipient.",
+                    "type": "boolean"
+                },
                 "lockFile": {
                     "description": "The path on the pod to the cluster lock file that definesthe distributed validator cluster. (default \"/charon-data/cluster-lock.json\")",
                     "type": "string"

--- a/charts/dv-pod/values.yaml
+++ b/charts/dv-pod/values.yaml
@@ -90,6 +90,9 @@ charon:
   # -- Comma-separated list of features to enable, overriding the default minimum feature set.
   featureSetEnable: ""
 
+  # -- Enables polling the Obol API for signed fee recipient update messages that override the currently configured fee recipient.
+  fetchFeeRecipientUpdates: true
+
   # -- The path on the pod to the cluster lock file that definesthe distributed validator cluster. (default "/charon-data/cluster-lock.json")
   lockFile: "/charon-data/cluster-lock.json"
 


### PR DESCRIPTION
## Summary
- Adds a new `charon.fetchFeeRecipientUpdates` helm value (defaults to `true`) that renders the charon `--fetch-feerecipient-updates` CLI flag on the main charon container.
- When enabled, charon polls the Obol API for signed fee recipient update messages that override the currently configured fee recipient. Charon's own default for this flag is `false`, so this chart default flips it on.
- Flag is rendered unconditionally so users who set the value to `false` still get `--fetch-feerecipient-updates=false` passed explicitly.

## Test plan
- [x] `helm lint charts/dv-pod` passes
- [x] `helm template` renders `--fetch-feerecipient-updates=true` by default
- [x] `helm template --set charon.fetchFeeRecipientUpdates=false` renders `--fetch-feerecipient-updates=false`
- [x] `make docs` regenerated `charts/dv-pod/README.md` cleanly
- [x] Deploy a dv-pod with the new default and confirm charon starts with the flag enabled