### PR TITLE
bump(remote-signer): chart 0.3.1, appVersion v0.2.0

### DIFF
--- a/charts/remote-signer/Chart.yaml
+++ b/charts/remote-signer/Chart.yaml
@@ -16,8 +16,8 @@ keywords:
   - obol
   - keystore
 type: application
-version: 0.3.0
-appVersion: "v0.1.0"
+version: 0.3.1
+appVersion: "v0.2.0"
 annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/signKey: |

--- a/charts/remote-signer/README.md
+++ b/charts/remote-signer/README.md
@@ -1,6 +1,6 @@
 # remote-signer
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.0](https://img.shields.io/badge/AppVersion-v0.1.0-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
 
 A lightweight Ethereum remote signing service for EVM networks. Multi-chain native with per-request chain_id.
 


### PR DESCRIPTION
## Summary
- Bumps `charts/remote-signer` from `0.3.0` → `0.3.1`
- Points `appVersion` at the new `v0.2.0` image of [`remote-signer`](https://github.com/ObolNetwork/remote-signer) (canonical string transaction schema + CI / supply-chain hardening since `v0.1.0`)
- README badges refreshed to match

Flagged by platform: the chart on `main` was still pointing at `v0.1.0`, so openclaw's pinned `remoteSignerChartVersion = "0.3.0"` ([openclaw.go:53](https://github.com/ObolNetwork/obol-stack/blob/main/internal/openclaw/openclaw.go#L53)) was resolving to the stale image. After this merges + the chart is published, openclaw can be bumped to `0.3.1`.

## Test plan
- [ ] CI lint / `helm lint charts/remote-signer`
- [ ] Chart published to `https://obolnetwork.github.io/helm-charts/` as `remote-signer-0.3.1`
- [ ] `helm show chart obol/remote-signer --version 0.3.1` reports `appVersion: v0.2.0`
- [ ] Follow-up: bump `remoteSignerChartVersion` to `0.3.1` in obol-stack