### PR TITLE
fix(dv-pod): default fetchFeeRecipientUpdates to true when nil

### DIFF
--- a/charts/dv-pod/templates/statefulset.yaml
+++ b/charts/dv-pod/templates/statefulset.yaml
@@ -538,7 +538,7 @@ spec:
               {{- if .Values.charon.featureSetEnable }}
               --feature-set-enable={{ .Values.charon.featureSetEnable }}
               {{- end }}
-              --fetch-feerecipient-updates={{ .Values.charon.fetchFeeRecipientUpdates }}
+              --fetch-feerecipient-updates={{ if kindIs "invalid" .Values.charon.fetchFeeRecipientUpdates }}true{{ else }}{{ .Values.charon.fetchFeeRecipientUpdates }}{{ end }}
               {{- if .Values.charon.logFormat }}
               --log-format={{ .Values.charon.logFormat }}
               {{- end }}


### PR DESCRIPTION
## Summary
- `helm upgrade --reuse-values` from a chart predating the `charon.fetchFeeRecipientUpdates` key (e.g. `dv-pod-0.17.0`/`0.18.x`) carries forward the previous release's effective values **without** merging the upgraded chart's new `values.yaml` defaults. The template then resolved `.Values.charon.fetchFeeRecipientUpdates` to nil and rendered `--fetch-feerecipient-updates=` (empty), and charon refused to start with `invalid argument "" for "--fetch-feerecipient-updates" flag: strconv.ParseBool: parsing "": invalid syntax`.
- Fix renders `true` when the value is nil while preserving an explicit `true` or `false` from the user. Keeps PR #272's "always render the flag" intent so charon's own `false` default never silently takes over.
- Mitigates the issue for any operator who upgrades with `--reuse-values` (the long-standing default many docs and habits assume) without having to know about `--reset-then-reuse-values`.

## Test plan
- [x] `helm template charts/dv-pod --set charon.fetchFeeRecipientUpdates=null` → renders `--fetch-feerecipient-updates=true`
- [x] `helm template charts/dv-pod --set charon.fetchFeeRecipientUpdates=true` → renders `--fetch-feerecipient-updates=true`
- [x] `helm template charts/dv-pod --set charon.fetchFeeRecipientUpdates=false` → renders `--fetch-feerecipient-updates=false`
- [x] `helm template charts/dv-pod` (default) → renders `--fetch-feerecipient-updates=true`
- [x] `helm lint charts/dv-pod` passes
- [x] `make docs` produces no diff (template-only change)
- [ ] Reviewer confirms `Auto Version Bump` workflow ticks chart `0.19.0` → `0.19.1` (patch — appVersion unchanged)