### PR TITLE
bump(dv-pod): chart 0.19.1 to publish PR #283 fix

### DIFF
--- a/charts/dv-pod/Chart.yaml
+++ b/charts/dv-pod/Chart.yaml
@@ -31,7 +31,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.19.0
+version: 0.19.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/dv-pod/README.md
+++ b/charts/dv-pod/README.md
@@ -2,7 +2,7 @@
 DV-Pod
 ===========
 
-![Version: 0.19.0](https://img.shields.io/badge/Version-0.19.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.0](https://img.shields.io/badge/AppVersion-1.10.0-informational?style=flat-square)
+![Version: 0.19.1](https://img.shields.io/badge/Version-0.19.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.0](https://img.shields.io/badge/AppVersion-1.10.0-informational?style=flat-square)
 
 A Helm chart for deploying a single distributed validator pod consisting of a Charon middleware client and validator client.
 


### PR DESCRIPTION
## Summary
- PR #283 (defensive `--fetch-feerecipient-updates` template render) merged without a chart-version bump because the `Auto Version Bump` workflow is gated on `github.actor == 'renovate[bot]'` and #283 was human-authored.
- With chart `0.19.0` unchanged, `chart-releaser-action` saw the version already published and skipped — so the fix is on `main` but not in the helm repo.
- Patch bump (`0.19.0` → `0.19.1`) to publish. AppVersion stays at `1.10.0` (no charon change).

## Test plan
- [x] `helm lint charts/dv-pod` passes
- [x] `make docs` regenerated `charts/dv-pod/README.md` (only the version badge changed)
- [x] No `values.yaml` change → `values.schema.json` unaffected, no regeneration needed
- [ ] After merge: `Release Charts` workflow publishes `dv-pod-0.19.1` to the helm repo

## Followup (separate PR)
The actor gate on `.github/workflows/version-bump.yml` makes the workflow skip every human-authored chart change. The workflow is idempotent (it short-circuits if the chart version was already bumped in the PR), so the gate could be dropped to cover this case for future contributors.