### PR TITLE
feat(charon-relay): add p2pUdpAddress config to enable QUIC transport

### DIFF
--- a/.github/helm-ci-values/skip-charts.txt
+++ b/.github/helm-ci-values/skip-charts.txt
@@ -4,3 +4,4 @@ obol-app
 aztec-node
 openclaw
 charon
+charon-dv-node

--- a/charts/charon-relay/README.md
+++ b/charts/charon-relay/README.md
@@ -44,6 +44,7 @@ Charon is an open-source Ethereum Distributed validator middleware written in go
 | config.p2pRelayLogLevel | string | `"debug"` |  |
 | config.p2pRelays | string | `""` | Comma-separated list of libp2p relay URLs or multiaddrs. (default [https://0.relay.obol.tech/enr]) |
 | config.p2pTcpAddress | string | `"0.0.0.0:3610"` | Comma-separated list of listening TCP addresses (ip and port) for libP2P traffic. Empty default doesn't bind to local port therefore only supports outgoing connections. |
+| config.p2pUdpAddress | string | `""` | Listening UDP address (ip and port) for QUIC libP2P traffic. When set, enables QUIC transport and the relay advertises a /udp/<port>/quic-v1 multiaddr. Requires a separate UDP LoadBalancer service exposing this port. |
 | containerSecurityContext | object | See `values.yaml` | The security context for containers |
 | fullnameOverride | string | `""` | Provide a name to substitute for the full names of resources |
 | httpRoute.annotations | object | `{}` |  |

--- a/charts/charon-relay/templates/statefulset.yaml
+++ b/charts/charon-relay/templates/statefulset.yaml
@@ -139,6 +139,9 @@ spec:
               {{- if $.Values.config.p2pTcpAddress }}
               --p2p-tcp-address={{ $.Values.config.p2pTcpAddress }}
               {{- end }}
+              {{- if $.Values.config.p2pUdpAddress }}
+              --p2p-udp-address={{ $.Values.config.p2pUdpAddress }}
+              {{- end }}
           env:
           - name: NODE_NAME
             valueFrom:

--- a/charts/charon-relay/values.yaml
+++ b/charts/charon-relay/values.yaml
@@ -214,6 +214,9 @@ config:
   # -- Comma-separated list of listening TCP addresses (ip and port) for libP2P traffic. Empty default doesn't bind to local port therefore only supports outgoing connections.
   p2pTcpAddress: "0.0.0.0:3610"
 
+  # -- Listening UDP address (ip and port) for QUIC libP2P traffic. When set, enables QUIC transport and the relay advertises a /udp/<port>/quic-v1 multiaddr. Requires a separate UDP LoadBalancer service exposing this port.
+  p2pUdpAddress: ""
+
 # -- Prometheus Service Monitor
 ## ref: https://github.com/coreos/prometheus-operator
 serviceMonitor:


### PR DESCRIPTION
## Summary

- Adds `config.p2pUdpAddress` field to `charon-relay` chart values (defaults to `""` / disabled)
- Wires `--p2p-udp-address` flag into the StatefulSet command when the value is set
- Skips `charon-dv-node` in `helm-lint` pre-commit hook (no `Chart.yaml`, pre-existing issue)

When `config.p2pUdpAddress` is set (e.g. `0.0.0.0:3630`), Charon binds UDP and advertises a `/udp/<port>/quic-v1` multiaddr, enabling QUIC transport for relay peers. A separate UDP LoadBalancer service must expose the configured port.

## Test plan

- [ ] Deploy relay-3 (ArgoCD) with `p2pUdpAddress: "0.0.0.0:3630"` and verify `curl https://<relay>/` shows `/quic-v1` in multiaddrs
- [ ] Confirm no regression for relays without `p2pUdpAddress` set (defaults to TCP-only)