### PR TITLE
feat(charon-relay): add UDP LoadBalancer services for QUIC

### DIFF
--- a/charts/charon-relay/Chart.yaml
+++ b/charts/charon-relay/Chart.yaml
@@ -29,7 +29,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.7.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/charon-relay/README.md
+++ b/charts/charon-relay/README.md
@@ -2,7 +2,7 @@
 Charon Relay
 ===========
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.0](https://img.shields.io/badge/AppVersion-1.10.0-informational?style=flat-square)
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.0](https://img.shields.io/badge/AppVersion-1.10.0-informational?style=flat-square)
 
 Charon is an open-source Ethereum Distributed validator middleware written in golang. This chart deploys a libp2p relay server.
 
@@ -74,7 +74,8 @@ Charon is an open-source Ethereum Distributed validator middleware written in go
 | readinessProbe | object | `{"enabled":true,"httpGet":{"path":"/readyz"},"initialDelaySeconds":5,"periodSeconds":3}` | Configure readiness probes # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/ |
 | resources | object | `{}` | Pod resources limits and requests |
 | securityContext | object | See `values.yaml` | The security context for pods |
-| service | object | `{"ports":{"http":{"name":"relay-http","port":3640,"protocol":"TCP","targetPort":3640},"monitoring":{"name":"monitoring","port":3620,"protocol":"TCP","targetPort":3620},"p2pTcp":{"name":"p2p-tcp","port":3610,"protocol":"TCP","targetPort":3610}},"type":"LoadBalancer"}` | Charon service ports |
+| service | object | `{"ports":{"http":{"name":"relay-http","port":3640,"protocol":"TCP","targetPort":3640},"monitoring":{"name":"monitoring","port":3620,"protocol":"TCP","targetPort":3620},"p2pTcp":{"name":"p2p-tcp","port":3610,"protocol":"TCP","targetPort":3610}},"type":"LoadBalancer","udpAnnotations":{}}` | Charon service ports |
+| service.udpAnnotations | object | `{}` | Annotations for UDP LoadBalancer services (created when config.p2pUdpAddress is set) |
 | serviceAccount | object | `{"annotations":{},"enabled":true,"name":""}` | Service account # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/ |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.enabled | bool | `true` | Specifies whether a service account should be created |

--- a/charts/charon-relay/templates/service.yaml
+++ b/charts/charon-relay/templates/service.yaml
@@ -24,4 +24,26 @@ spec:
       targetPort: {{ $.Values.service.ports.monitoring.targetPort }}
   selector:
     name: {{ include "release.name" $ }}-{{ $i }}
+{{- if $.Values.config.p2pUdpAddress }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "release.name" $ }}-{{ $i }}-udp
+  namespace: {{ $.Release.Namespace }}
+  {{- with $.Values.service.udpAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ $.Values.service.type }}
+  externalTrafficPolicy: Local
+  selector:
+    name: {{ include "release.name" $ }}-{{ $i }}
+  ports:
+    - name: p2p-udp
+      protocol: UDP
+      port: 3630
+      targetPort: 3630
+{{- end }}
 {{- end }}

--- a/charts/charon-relay/values.yaml
+++ b/charts/charon-relay/values.yaml
@@ -86,6 +86,8 @@ rbac:
 # -- Charon service ports
 service:
   type: LoadBalancer
+  # -- Annotations for UDP LoadBalancer services (created when config.p2pUdpAddress is set)
+  udpAnnotations: {}
   ports:
     http:
       name: relay-http


### PR DESCRIPTION
## Summary

- When `config.p2pUdpAddress` is set, the chart now creates a UDP LoadBalancer service per relay pod on port 3630
- Cloud-specific annotations (e.g. AWS NLB) can be set via `service.udpAnnotations`
- Chart version bumped to 0.7.0

This completes QUIC support in the chart — previously only the `--p2p-udp-address` flag was wired up (0.6.0) but no UDP services were created.

## Test plan

- [ ] Deploy with `p2pUdpAddress: "0.0.0.0:3630"` and verify UDP services are created
- [ ] Deploy without `p2pUdpAddress` and verify no UDP services are created
- [ ] Verify `curl https://<relay>/` shows `/quic-v1` multiaddrs