### PR TITLE
feat(charon-relay): split metrics port to ClusterIP-only Service

### DIFF
--- a/charts/charon-relay/Chart.yaml
+++ b/charts/charon-relay/Chart.yaml
@@ -29,7 +29,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/charon-relay/README.md
+++ b/charts/charon-relay/README.md
@@ -2,7 +2,7 @@
 Charon Relay
 ===========
 
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.0](https://img.shields.io/badge/AppVersion-1.10.0-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.0](https://img.shields.io/badge/AppVersion-1.10.0-informational?style=flat-square)
 
 Charon is an open-source Ethereum Distributed validator middleware written in golang. This chart deploys a libp2p relay server.
 
@@ -59,6 +59,7 @@ Charon is an open-source Ethereum Distributed validator middleware written in go
 | imagePullSecrets | list | `[]` | Credentials to fetch images from private registry # ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/ |
 | initContainerImage | string | `"alpine/kubectl:1.35.2"` | Init container image |
 | livenessProbe | object | `{"enabled":true,"httpGet":{"path":"/livez"},"initialDelaySeconds":10,"periodSeconds":5}` | Configure liveness probes # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/ |
+| metricsService | object | `{"enabled":false}` | When enabled, the metrics port (service.ports.monitoring) is removed from the main (LoadBalancer) Service above and exposed on a separate ClusterIP Service `{release}-{index}-metrics` so the port is not reachable from the public LoadBalancer. ServiceMonitor (if enabled) auto-selects the right Service. Default false to preserve the legacy behaviour. |
 | nameOverride | string | `""` | Provide a name in place of lighthouse for `app:` labels |
 | nodeSelector | object | `{}` | Node labels for pod assignment # ref: https://kubernetes.io/docs/user-guide/node-selection/ |
 | podAnnotations | object | `{}` | Pod annotations |

--- a/charts/charon-relay/templates/prometheus-configmap.yaml
+++ b/charts/charon-relay/templates/prometheus-configmap.yaml
@@ -22,7 +22,11 @@ data:
     {{- range $i := until (int .Values.clusterSize) }}
       - job_name: '{{ include "release.name" $ }}-{{ $i }}'
         static_configs:
-          - targets: ['{{ include "release.name" $ }}-{{ $i }}:3620']
+          {{- if $.Values.metricsService.enabled }}
+          - targets: ['{{ include "release.name" $ }}-{{ $i }}-metrics:{{ $.Values.service.ports.monitoring.port }}']
+          {{- else }}
+          - targets: ['{{ include "release.name" $ }}-{{ $i }}:{{ $.Values.service.ports.monitoring.port }}']
+          {{- end }}
         relabel_configs:
           - target_label: relay_cluster_name
             replacement: obol-{{ $.Release.Namespace }}-{{ $i }}

--- a/charts/charon-relay/templates/service.yaml
+++ b/charts/charon-relay/templates/service.yaml
@@ -18,12 +18,37 @@ spec:
       protocol: {{ $.Values.service.ports.p2pTcp.protocol }}
       port: {{ $.Values.service.ports.p2pTcp.port }}
       targetPort: {{ $.Values.service.ports.p2pTcp.targetPort }}
+    {{- if not $.Values.metricsService.enabled }}
+    - name: {{ $.Values.service.ports.monitoring.name }}
+      protocol: {{ $.Values.service.ports.monitoring.protocol }}
+      port: {{ $.Values.service.ports.monitoring.port }}
+      targetPort: {{ $.Values.service.ports.monitoring.targetPort }}
+    {{- end }}
+  selector:
+    name: {{ include "release.name" $ }}-{{ $i }}
+{{- if $.Values.metricsService.enabled }}
+---
+# Separate ClusterIP Service for metrics so port 3620 is not exposed by
+# the public LoadBalancer above. In-cluster scrapers (ServiceMonitor or
+# Prometheus pod_sd) hit this Service instead.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "release.name" $ }}-{{ $i }}-metrics
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    name: {{ include "release.name" $ }}-{{ $i }}-metrics
+    app.kubernetes.io/component: metrics
+spec:
+  type: ClusterIP
+  ports:
     - name: {{ $.Values.service.ports.monitoring.name }}
       protocol: {{ $.Values.service.ports.monitoring.protocol }}
       port: {{ $.Values.service.ports.monitoring.port }}
       targetPort: {{ $.Values.service.ports.monitoring.targetPort }}
   selector:
     name: {{ include "release.name" $ }}-{{ $i }}
+{{- end }}
 {{- if $.Values.config.p2pUdpAddress }}
 ---
 apiVersion: v1

--- a/charts/charon-relay/templates/servicemonitor.yaml
+++ b/charts/charon-relay/templates/servicemonitor.yaml
@@ -21,7 +21,7 @@ spec:
     scrapeTimeout: {{ $.Values.serviceMonitor.scrapeTimeout }}
     {{- end }}
     honorLabels: true
-    port: metrics
+    port: {{ $.Values.service.ports.monitoring.name }}
     path: {{ $.Values.serviceMonitor.path }}
     scheme: {{ $.Values.serviceMonitor.scheme }}
     {{- if $.Values.serviceMonitor.tlsConfig }}
@@ -35,7 +35,11 @@ spec:
   jobLabel: "{{ $.Release.Name }}-{{ $i }}"
   selector:
     matchLabels:
+      {{- if $.Values.metricsService.enabled }}
+      name: {{ include "release.name" $ }}-{{ $i }}-metrics
+      {{- else }}
       name: {{ include "release.name" $ }}-{{ $i }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ $.Release.Namespace }}

--- a/charts/charon-relay/values.yaml
+++ b/charts/charon-relay/values.yaml
@@ -105,6 +105,14 @@ service:
       protocol: TCP
       targetPort: 3620
 
+# -- When enabled, the metrics port (service.ports.monitoring) is removed from
+# the main (LoadBalancer) Service above and exposed on a separate ClusterIP
+# Service `{release}-{index}-metrics` so the port is not reachable from the
+# public LoadBalancer. ServiceMonitor (if enabled) auto-selects the right
+# Service. Default false to preserve the legacy behaviour.
+metricsService:
+  enabled: false
+
 # -- Pod resources limits and requests
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
## Context

The default \`charon-relay\` Service exposes port 3620 (Charon \`--monitoring-address\`) on the public LoadBalancer alongside the P2P (3610) and HTTP (3640) ports. Metrics are only ever scraped in-cluster, so 3620 has no reason to be reachable from the public internet.

Ref: ObolNetwork/obol-infrastructure#2652

## Changes

- New \`metricsService.enabled\` toggle in \`values.yaml\` (default \`false\` to preserve existing behaviour).
- When enabled:
  - Port 3620 is removed from the LoadBalancer Service.
  - A new ClusterIP-only Service \`{release}-{i}-metrics\` exposes 3620.
  - ServiceMonitor (when also enabled) selects the metrics Service via its dedicated label.
- ServiceMonitor template fix: the endpoint \`port\` was hardcoded to \`metrics\` but the Service port name is \`monitoring\` (from \`service.ports.monitoring.name\`). Now uses \`{{ .Values.service.ports.monitoring.name }}\` so the two stay in sync regardless of mode.
- Bump chart to \`0.8.0\`.

## Verification

\`\`\`bash
# Legacy mode (default): port 3620 still on LB
helm template test charts/charon-relay --set clusterSize=1 | yq 'select(.kind == "Service")'

# New mode: port 3620 off LB, separate ClusterIP Service exists
helm template test charts/charon-relay --set clusterSize=1 \\
  --set metricsService.enabled=true --set serviceMonitor.enabled=true \\
  | yq 'select(.kind == "Service" or .kind == "ServiceMonitor")'
\`\`\`

## Migration

Existing releases keep working unchanged. To opt-in:

\`\`\`yaml
metricsService:
  enabled: true
serviceMonitor:
  enabled: true   # if you have prometheus-operator
\`\`\`

This is non-breaking. The metrics endpoint URL changes from \`{lb-ip}:3620\` to \`{release}-{i}-metrics.{ns}.svc.cluster.local:3620\` — only relevant for external scrapers, which shouldn't exist (the whole point of this change).