### PR TITLE
fix(charon-relay): restrict metrics endpoint to cluster-internal access

### DIFF
--- a/charts/charon-relay/Chart.yaml
+++ b/charts/charon-relay/Chart.yaml
@@ -29,7 +29,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/charon-relay/README.md
+++ b/charts/charon-relay/README.md
@@ -2,7 +2,7 @@
 Charon Relay
 ===========
 
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.0](https://img.shields.io/badge/AppVersion-1.10.0-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.10.0](https://img.shields.io/badge/AppVersion-1.10.0-informational?style=flat-square)
 
 Charon is an open-source Ethereum Distributed validator middleware written in golang. This chart deploys a libp2p relay server.
 

--- a/charts/charon-relay/templates/prometheus-configmap.yaml
+++ b/charts/charon-relay/templates/prometheus-configmap.yaml
@@ -22,7 +22,7 @@ data:
     {{- range $i := until (int .Values.clusterSize) }}
       - job_name: '{{ include "release.name" $ }}-{{ $i }}'
         static_configs:
-          - targets: ['{{ include "release.name" $ }}-{{ $i }}:3620']
+          - targets: ['{{ include "release.name" $ }}-{{ $i }}-metrics:3620']
         relabel_configs:
           - target_label: relay_cluster_name
             replacement: obol-{{ $.Release.Namespace }}-{{ $i }}

--- a/charts/charon-relay/templates/service.yaml
+++ b/charts/charon-relay/templates/service.yaml
@@ -18,8 +18,19 @@ spec:
       protocol: {{ $.Values.service.ports.p2pTcp.protocol }}
       port: {{ $.Values.service.ports.p2pTcp.port }}
       targetPort: {{ $.Values.service.ports.p2pTcp.targetPort }}
-    - name: {{ $.Values.service.ports.monitoring.name }}
-      protocol: {{ $.Values.service.ports.monitoring.protocol }}
+  selector:
+    name: {{ include "release.name" $ }}-{{ $i }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "release.name" $ }}-{{ $i }}-metrics
+  namespace: {{ $.Release.Namespace }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: monitoring
+      protocol: TCP
       port: {{ $.Values.service.ports.monitoring.port }}
       targetPort: {{ $.Values.service.ports.monitoring.targetPort }}
   selector:

--- a/charts/charon-relay/templates/servicemonitor.yaml
+++ b/charts/charon-relay/templates/servicemonitor.yaml
@@ -21,7 +21,7 @@ spec:
     scrapeTimeout: {{ $.Values.serviceMonitor.scrapeTimeout }}
     {{- end }}
     honorLabels: true
-    port: metrics
+    port: monitoring
     path: {{ $.Values.serviceMonitor.path }}
     scheme: {{ $.Values.serviceMonitor.scheme }}
     {{- if $.Values.serviceMonitor.tlsConfig }}


### PR DESCRIPTION
## Summary

- Move monitoring port (3620) from the public LoadBalancer service to a dedicated ClusterIP service per relay pod
- Update prometheus-configmap to scrape from `*-metrics:3620` instead of the main service
- Update servicemonitor port name to match the new service
- Chart version bumped to 0.8.0

## Test plan

- [ ] `helm template` shows separate ClusterIP metrics service per pod
- [ ] Monitoring port no longer appears on the LoadBalancer service
- [ ] Central monitoring prometheus config targets `*-metrics:3620`